### PR TITLE
fix(ci): update GitHub Actions to use Go 1.24.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24.3'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24.3'
 
       - name: Test version detection
         run: |


### PR DESCRIPTION
## Summary
- Updates GitHub Actions workflows to use Go 1.24.3 to match project toolchain requirement
- Fixes golangci-lint version compatibility error in CI

## Problem
The CI was failing with the error:
```
Error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.3)
```

This occurred because:
- The project's `go.mod` specifies `toolchain go1.24.3`
- The GitHub Actions workflows were using Go 1.21
- golangci-lint built with Go 1.23 cannot analyze code targeting Go 1.24.3

## Solution
Updated both workflow files:
- `.github/workflows/release.yml`
- `.github/workflows/test-release.yml`

To use `go-version: '1.24.3'` in the setup-go action.

## Test plan
- [x] CI should pass without golangci-lint version errors
- [x] All checks should complete successfully
