### PR TITLE
fix(ci): correct tag push command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,8 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           ./scripts/version-bump.sh
-          git push origin ${{ steps.version_check.outputs.new_version }}
+          # Push the newly created tag
+          git push origin --tags
 
       - name: Generate changelog
         if: steps.version_check.outputs.needs_release == 'true'


### PR DESCRIPTION
## Summary
- Fixes the tag push command in the release workflow to use `git push origin --tags`
- Resolves the "src refspec create does not match any" error

## Problem
The release workflow was failing with:
```
error: src refspec create does not match any
error: failed to push some refs to 'https://github.com/jmcarbo/oapix'
```

This occurred because:
1. The workflow extracted the new version from dry-run output
2. The actual `version-bump.sh` script creates the tag locally
3. The workflow tried to push using `${{ steps.version_check.outputs.new_version }}` which didn't match the actual tag reference

## Solution
Changed the push command from:
```bash
git push origin ${{ steps.version_check.outputs.new_version }}
```

To:
```bash
git push origin --tags
```

This ensures all newly created tags are pushed to the remote repository.

## Test plan
- [ ] The release workflow should successfully create and push version tags
- [ ] No "src refspec" errors should occur
- [ ] Tags should appear in the GitHub repository
