### PR TITLE
feat(gen): auto-convert int32 date fields to int64

### DIFF
--- a/examples/date-fields-test.yaml
+++ b/examples/date-fields-test.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  title: Date Fields Test API
+  version: 1.0.0
+  description: API to test automatic conversion of int32 date fields to int64
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          description: List of users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+          description: User ID (should remain int32)
+        createdDate:
+          type: integer
+          format: int32
+          description: Unix timestamp when user was created (should convert to int64)
+        updatedDate:
+          type: integer
+          format: int64
+          description: Unix timestamp when user was last updated (should remain int64)
+        lastLoginDate:
+          type: integer
+          format: int32
+          description: Unix timestamp of last login (should convert to int64)
+        age:
+          type: integer
+          format: int32
+          description: User age in years (should remain int32)
+        registrationDateMillis:
+          type: integer
+          format: int32
+          description: Registration date in milliseconds (should convert to int64)
+        score:
+          type: integer
+          format: int32
+          description: User score (should remain int32)

--- a/pkg/gen/generator_test.go
+++ b/pkg/gen/generator_test.go
@@ -1008,3 +1008,85 @@ paths:
 		t.Error("Expected GetUsers2 from operationId get_users_2")
 	}
 }
+
+func TestSchemaToGoTypeWithDateFields(t *testing.T) {
+	config := &Config{
+		PackageName: "testpkg",
+	}
+
+	gen, err := NewGenerator(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		fieldName string
+		schema    *openapi3.Schema
+		want      string
+	}{
+		{
+			name:      "int32 date field should convert to int64",
+			fieldName: "createdDate",
+			schema: &openapi3.Schema{
+				Type:   &openapi3.Types{"integer"},
+				Format: "int32",
+			},
+			want: "int64",
+		},
+		{
+			name:      "int32 non-date field should remain int32",
+			fieldName: "count",
+			schema: &openapi3.Schema{
+				Type:   &openapi3.Types{"integer"},
+				Format: "int32",
+			},
+			want: "int32",
+		},
+		{
+			name:      "int64 date field should remain int64",
+			fieldName: "updatedDate",
+			schema: &openapi3.Schema{
+				Type:   &openapi3.Types{"integer"},
+				Format: "int64",
+			},
+			want: "int64",
+		},
+		{
+			name:      "case insensitive date detection",
+			fieldName: "lastModifiedDATE",
+			schema: &openapi3.Schema{
+				Type:   &openapi3.Types{"integer"},
+				Format: "int32",
+			},
+			want: "int64",
+		},
+		{
+			name:      "date in middle of field name",
+			fieldName: "userDateCreated",
+			schema: &openapi3.Schema{
+				Type:   &openapi3.Types{"integer"},
+				Format: "int32",
+			},
+			want: "int64",
+		},
+		{
+			name:      "string date should be time.Time",
+			fieldName: "createdDate",
+			schema: &openapi3.Schema{
+				Type:   &openapi3.Types{"string"},
+				Format: "date-time",
+			},
+			want: "time.Time",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := gen.schemaToGoTypeWithName(tt.schema, tt.fieldName)
+			if got != tt.want {
+				t.Errorf("schemaToGoTypeWithName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Automatically convert integer fields with "Date" in their name from int32 to int64 format
- Prevents Y2038 problem where Unix timestamps stored as int32 will overflow
- Case-insensitive detection applies to any field containing "date" in the name

## Rationale
Unix timestamps are commonly stored as integers in APIs. When these are defined as int32, they will overflow on January 19, 2038, causing the "Year 2038 problem". By automatically converting date-related int32 fields to int64, we ensure generated code is future-proof without requiring manual API spec modifications.

## Implementation Details
- Added new methods `schemaRefToGoTypeWithName`, `schemaToGoTypeWithName`, and `schemaToGoTypeWithNameNonNullable` that accept field name context
- Detection is case-insensitive (checks for "date" in lowercase field name)
- Only affects integer types with format int32; int64 fields remain unchanged
- String date fields (format: date/date-time) continue to map to time.Time as before

## Test Plan
- [x] Added comprehensive unit tests in `generator_test.go`
- [x] Created example OpenAPI spec `date-fields-test.yaml` demonstrating the conversion
- [x] Verified generated code correctly converts date fields while preserving non-date int32 fields
- [x] All existing tests pass
- [x] Linting and formatting checks pass