### PR TITLE
fix(gen): generate string type aliases for simple string schemas without enum

### DIFF
--- a/pkg/gen/generator.go
+++ b/pkg/gen/generator.go
@@ -253,11 +253,12 @@ func (g *Generator) generateFile(templateName string, data interface{}, outputPa
 
 // Model represents a Go model generated from an OpenAPI schema
 type Model struct {
-	Name        string
-	Description string
-	Fields      []Field
-	IsEnum      bool
-	EnumValues  []string
+	Name          string
+	Description   string
+	Fields        []Field
+	IsEnum        bool
+	EnumValues    []string
+	IsStringAlias bool // true for simple string types without enum
 }
 
 // Field represents a field in a model
@@ -347,6 +348,12 @@ func (g *Generator) schemaToModel(name string, schema *openapi3.Schema) *Model {
 				model.EnumValues = append(model.EnumValues, str)
 			}
 		}
+		return model
+	}
+
+	// Handle simple string types (without enum)
+	if schema.Type != nil && schema.Type.Is("string") {
+		model.IsStringAlias = true
 		return model
 	}
 

--- a/pkg/gen/generator_test.go
+++ b/pkg/gen/generator_test.go
@@ -247,6 +247,12 @@ func TestExtractModels(t *testing.T) {
 						Enum: []interface{}{"active", "inactive", "pending"},
 					},
 				},
+				"SimpleString": {
+					Value: &openapi3.Schema{
+						Type: &stringType,
+						Description: "A simple string without enum",
+					},
+				},
 			},
 		},
 	}
@@ -254,8 +260,8 @@ func TestExtractModels(t *testing.T) {
 	gen := &Generator{spec: spec}
 	models := gen.extractModels()
 
-	if len(models) != 2 {
-		t.Errorf("extractModels() returned %d models, want 2", len(models))
+	if len(models) != 3 {
+		t.Errorf("extractModels() returned %d models, want 3", len(models))
 	}
 
 	// Check User model
@@ -313,6 +319,34 @@ func TestExtractModels(t *testing.T) {
 	if len(statusModel.EnumValues) != 3 {
 		t.Errorf("Status enum has %d values, want 3", len(statusModel.EnumValues))
 	}
+
+	// Check SimpleString model - should be a simple string type alias, not a struct
+	var simpleStringModel *Model
+	for i := range models {
+		if models[i].Name == "SimpleString" {
+			simpleStringModel = &models[i]
+			break
+		}
+	}
+
+	if simpleStringModel == nil {
+		t.Fatal("SimpleString model not found")
+	}
+
+	if simpleStringModel.IsEnum {
+		t.Error("SimpleString model should not be an enum")
+	}
+
+	if len(simpleStringModel.Fields) > 0 {
+		t.Errorf("SimpleString model should not have fields (should be a string type alias), but has %d fields: %+v", len(simpleStringModel.Fields), simpleStringModel.Fields)
+	}
+
+	if !simpleStringModel.IsStringAlias {
+		t.Error("SimpleString model should be marked as IsStringAlias=true")
+	}
+
+	// Debug: print the model to see what we're getting
+	t.Logf("SimpleString model: %+v", *simpleStringModel)
 }
 
 func TestGenerateFromReader(t *testing.T) {

--- a/pkg/gen/templates/models.tmpl
+++ b/pkg/gen/templates/models.tmpl
@@ -19,6 +19,9 @@ const (
 	{{$model.Name}}{{toPascalCase $value}} {{$model.Name}} = "{{$value}}"
 {{- end}}
 )
+{{else if .IsStringAlias}}
+{{if .Description}}{{goDoc .Description ""}}{{end}}
+type {{.Name}} string
 {{else}}
 {{if .Description}}{{goDoc .Description ""}}{{end}}
 type {{.Name}} struct {


### PR DESCRIPTION
## Summary
This PR fixes the generation of simple string types in OpenAPI schemas. Previously, string schemas without enum values were incorrectly generated as empty structs (`struct{}`), while string schemas with enum values were correctly generated as string type aliases.

## Changes
The `schemaToModel` function in `generator.go` only handled two cases:
1. Schemas with enum values → correctly generated as string type aliases
2. Object schemas with properties → correctly generated as structs

Simple string schemas (without enum or properties) fell through to the default case, creating empty models that rendered as `struct{}`.

1. **Added `IsStringAlias` field** to the `Model` struct to distinguish simple string types
2. **Enhanced `schemaToModel`** to detect `type: string` schemas without enum values
3. **Updated template** to render string aliases as `type Name string` instead of empty structs
4. **Added comprehensive tests** to prevent regression

## Testing
  ```go
  // Before: type SimpleString struct {}
  // After:  type SimpleString string 

  // Enum strings remain unchanged
  type StatusEnum string // (unchanged)

  All existing tests pass, and the new test case ensures simple strings are correctly identified and generated.
  ```